### PR TITLE
Support for additional package archive types

### DIFF
--- a/source/gpm-tests/GenericHost.cs
+++ b/source/gpm-tests/GenericHost.cs
@@ -1,5 +1,6 @@
 using gpm.core.Models;
 using gpm.core.Services;
+using gpm.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Serilog;
@@ -37,12 +38,15 @@ namespace gpm_tests
                         //services.AddScoped<IAppSettings, AppSettings>();
                         //services.AddScoped<ILoggerService, MicrosoftLoggerService>();
                         services.AddScoped<IProgressService<double>, PercentProgressService>();
+                        services.AddScoped<IArchiveService, ArchiveService>();
 
                         services.AddSingleton<ILibraryService, LibraryService>();
                         services.AddSingleton<IDataBaseService, DataBaseService>();
 
                         services.AddSingleton<IDeploymentService, DeploymentService>();
                         services.AddSingleton<IGitHubService, GitHubService>();
+
+                        services.AddSingleton<ITaskService, TaskService>();
 
                         services.AddOptions<CommonSettings>()
                             .Bind(hostContext.Configuration.GetSection(nameof(CommonSettings)));

--- a/source/gpm-tests/IntegrationTests.cs
+++ b/source/gpm-tests/IntegrationTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Serilog;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using gpm.core;
 
 namespace gpm_tests
 {
@@ -35,8 +36,13 @@ namespace gpm_tests
 
         private static string GetTestSlot(int i)
         {
-            var folder = Path.Combine(IAppSettings.GetAppDataFolder(),
-                $"TESTSLOT{i.ToString()}"
+            //Path.Combine(
+           
+
+            var folder = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                Constants.APPDATA,
+                $"TESTSLOT{i}"
             );
             if (!Directory.Exists(folder))
             {
@@ -97,10 +103,10 @@ namespace gpm_tests
                 await taskService.Remove(TESTNAME3, false, "", i);
             }
 
-            Directory.Delete(TESTSLOT0,true);
-            Directory.Delete(TESTSLOT1,true);
-            Directory.Delete(TESTSLOT2,true);
-            Directory.Delete(TESTSLOT3,true);
+            //Directory.Delete(TESTSLOT0, true);
+            Directory.Delete(TESTSLOT1, true);
+            Directory.Delete(TESTSLOT2, true);
+            Directory.Delete(TESTSLOT3, true);
         }
 
         [TestMethod]

--- a/source/gpm-tests/UnitTests.cs
+++ b/source/gpm-tests/UnitTests.cs
@@ -17,7 +17,7 @@ namespace gpm_tests
     {
         private readonly IHost _host;
 
-        private const string TESTNAME = "wolvenkit";
+        private const string TESTNAME = "wolvenkit/wolvenkit/test1";
         private const string TESTVERSION1 = "8.4.2";
 
         public UnitTests()
@@ -72,7 +72,7 @@ namespace gpm_tests
             var asset = assetBuilder.Build(release.Assets);
 
             Assert.IsNotNull(asset);
-            Assert.AreEqual("WolvenKit-8.4.2.zip", asset.Name);
+            Assert.AreEqual("manifest.json", asset.Name);
 
             // TODO: test install builder
 

--- a/source/gpm.core/Enums.cs
+++ b/source/gpm.core/Enums.cs
@@ -4,6 +4,7 @@ namespace gpm.core
     {
         SingleFile,
         ZipArchive,
-        SevenZipArchive
+        SevenZipArchive,
+        Archive
     }
 }

--- a/source/gpm.core/Services/ArchiveService.cs
+++ b/source/gpm.core/Services/ArchiveService.cs
@@ -4,7 +4,7 @@ using SharpCompress.Readers;
 
 namespace gpm.core.Services
 {
-    public class SharpCompressService : IArchiveService
+    public class ArchiveService : IArchiveService
     {
         public PlatformID[] SupportedPlatforms { get; } = { PlatformID.Win32NT, PlatformID.Unix };
 

--- a/source/gpm.core/Services/DeploymentService.cs
+++ b/source/gpm.core/Services/DeploymentService.cs
@@ -210,15 +210,16 @@ namespace gpm.core.Services
 
             var installedFiles = new List<HashedFile>();
 
-            // TODO: Remove if not a fail-state.
             if (package.ContentType == null)
             {
-                Log.Warning($"[{package}] Failed to install package at '{assetCachePath}', `ContentType` property is not set. Aborting.");
+                package.ContentType = _archiveService.IsSupportedArchive(assetCachePath).Result
+                    ? EContentType.Archive
+                    : EContentType.SingleFile;
 
-                return false;
+                Log.Warning($"[{package}] `ContentType` property is not set in '{assetCachePath}', determined type based on file extension. Here be dragons.");
             } 
 
-            else if (package.ContentType == EContentType.SingleFile)
+            if (package.ContentType == EContentType.SingleFile)
             {
                 var releaseFileName = Path.GetFileName(assetCacheFile);
                 var assetDestinationPath = Path.Combine(destinationDir, releaseFileName);

--- a/source/gpm.core/Services/IArchiveService.cs
+++ b/source/gpm.core/Services/IArchiveService.cs
@@ -18,8 +18,8 @@ namespace gpm.core.Services
         /// <param name="destination">The destination directory.</param>
         /// <param name="overwrite">True to overwrite existing files and directories; otherwise false.</param>
         /// <param name="preserveRelativePaths">True to preserve file and directory paths relative to the archive; otherwise false.</param>
-        /// <returns></returns>
-        Task<bool> ExtractAsync(
+        /// <returns>A list of extracted file paths. Empty if none were extracted.</returns>
+        Task<List<string>> ExtractAsync(
             string archive,
             string destination,
             bool overwrite = false,
@@ -31,16 +31,15 @@ namespace gpm.core.Services
         /// <param name="archive">The archive to extract.</param>
         /// <param name="destination">The destination directory.</param>
         /// <param name="targetFiles">One or more file paths, relative to the path of the archive itself.</param>
-        /// <param name="fileDestinations">Destinations of files specified in targetFiles in (targetPath, destPath) pairs. Must be the same length if defined; otherwise null.</param>
         /// <param name="overwrite">True to overwrite existing files and directories; otherwise false.</param>
         /// <param name="preserveRelativePaths">True to preserve file and directory paths relative to the archive; otherwise false.</param>
-        /// <returns></returns>
-        Task<bool> ExtractFilesAsync(
+        /// <returns>A list of extracted file paths. Empty if none were extracted.</returns>
+        Task<List<string>> ExtractFilesAsync(
             string archive,
             string destination,
             List<string> targetFiles,
-            Dictionary<string, string>? fileDestinations = null,
             bool overwrite = false,
             bool preserveRelativePaths = false);
     }
 }
+

--- a/source/gpm.core/Services/IArchiveService.cs
+++ b/source/gpm.core/Services/IArchiveService.cs
@@ -5,10 +5,10 @@ namespace gpm.core.Services
         PlatformID[] SupportedPlatforms { get; }
 
         /// <summary>
-        /// Determine if the target archive can be extracted by this ArchiveService instance.
+        /// Determine if the target archive is supported by this ArchiveService instance.
         /// </summary>
         /// <param name="archive">The path of the target archive.</param>
-        /// <returns></returns>
+        /// <returns>True if the archive is supported by this instance, false if not.</returns>
         Task<bool> IsSupportedArchive(string archive);
 
         /// <summary>
@@ -31,7 +31,7 @@ namespace gpm.core.Services
         /// <param name="archive">The archive to extract.</param>
         /// <param name="destination">The destination directory.</param>
         /// <param name="targetFiles">One or more file paths, relative to the path of the archive itself.</param>
-        /// <param name="fileDestinations">Destinations of files specified in targetFiles. Must be the same length if defined; otherwise null.</param>
+        /// <param name="fileDestinations">Destinations of files specified in targetFiles in (targetPath, destPath) pairs. Must be the same length if defined; otherwise null.</param>
         /// <param name="overwrite">True to overwrite existing files and directories; otherwise false.</param>
         /// <param name="preserveRelativePaths">True to preserve file and directory paths relative to the archive; otherwise false.</param>
         /// <returns></returns>
@@ -39,7 +39,7 @@ namespace gpm.core.Services
             string archive,
             string destination,
             List<string> targetFiles,
-            List<string>? fileDestinations = null,
+            Dictionary<string, string>? fileDestinations = null,
             bool overwrite = false,
             bool preserveRelativePaths = false);
     }

--- a/source/gpm.core/Services/IArchiveService.cs
+++ b/source/gpm.core/Services/IArchiveService.cs
@@ -1,0 +1,46 @@
+namespace gpm.core.Services
+{
+    public interface IArchiveService
+    {
+        PlatformID[] SupportedPlatforms { get; }
+
+        /// <summary>
+        /// Determine if the target archive can be extracted by this ArchiveService instance.
+        /// </summary>
+        /// <param name="archive">The path of the target archive.</param>
+        /// <returns></returns>
+        Task<bool> IsSupportedArchive(string archive);
+
+        /// <summary>
+        /// Extract all files from the archive into the destination.
+        /// </summary>
+        /// <param name="archive">The archive to extract.</param>
+        /// <param name="destination">The destination directory.</param>
+        /// <param name="overwrite">True to overwrite existing files and directories; otherwise false.</param>
+        /// <param name="preserveRelativePaths">True to preserve file and directory paths relative to the archive; otherwise false.</param>
+        /// <returns></returns>
+        Task<bool> ExtractAsync(
+            string archive,
+            string destination,
+            bool overwrite = false,
+            bool preserveRelativePaths = true);
+
+        /// <summary>
+        /// Extract one or more files from the archive into the destination.
+        /// </summary>
+        /// <param name="archive">The archive to extract.</param>
+        /// <param name="destination">The destination directory.</param>
+        /// <param name="targetFiles">One or more file paths, relative to the path of the archive itself.</param>
+        /// <param name="fileDestinations">Destinations of files specified in targetFiles. Must be the same length if defined; otherwise null.</param>
+        /// <param name="overwrite">True to overwrite existing files and directories; otherwise false.</param>
+        /// <param name="preserveRelativePaths">True to preserve file and directory paths relative to the archive; otherwise false.</param>
+        /// <returns></returns>
+        Task<bool> ExtractFilesAsync(
+            string archive,
+            string destination,
+            List<string> targetFiles,
+            List<string>? fileDestinations = null,
+            bool overwrite = false,
+            bool preserveRelativePaths = false);
+    }
+}

--- a/source/gpm.core/Services/SharpCompressService.cs
+++ b/source/gpm.core/Services/SharpCompressService.cs
@@ -1,0 +1,31 @@
+using SharpCompress.Archives;
+
+namespace gpm.core.Services
+{
+    public class SharpCompressService : IArchiveService
+    {
+        public PlatformID[] SupportedPlatforms { get; } = { PlatformID.Win32NT, PlatformID.Unix };
+
+        public async Task<bool> IsSupportedArchive(string archive)
+        {
+            // Quick and dirty way to determine if SharpCompress supports a given archive.
+            try
+            {
+                _ = await Task.Run(() => ArchiveFactory.Open(archive));
+                return true;
+            }
+
+            catch (InvalidOperationException e)
+            {
+                return false;
+            }
+        }
+
+        public async Task<bool> ExtractAsync(string archive, string destination)
+        {
+            
+        }
+
+        public async Task<bool> ExtractFilesAsync(string archive, string destination, List<string> targetFiles) => throw new NotImplementedException();
+    }
+}

--- a/source/gpm.core/Services/SharpCompressService.cs
+++ b/source/gpm.core/Services/SharpCompressService.cs
@@ -1,4 +1,6 @@
 using SharpCompress.Archives;
+using SharpCompress.Common;
+using SharpCompress.Readers;
 
 namespace gpm.core.Services
 {
@@ -8,24 +10,82 @@ namespace gpm.core.Services
 
         public async Task<bool> IsSupportedArchive(string archive)
         {
-            // Quick and dirty way to determine if SharpCompress supports a given archive.
             try
             {
                 _ = await Task.Run(() => ArchiveFactory.Open(archive));
                 return true;
             }
 
-            catch (InvalidOperationException e)
+            catch (InvalidOperationException)
             {
                 return false;
             }
         }
-
-        public async Task<bool> ExtractAsync(string archive, string destination)
+        public async Task<bool> ExtractAsync(
+            string archive,
+            string destination,
+            bool overwrite = false,
+            bool preserveRelativePaths = true)
         {
-            
+            using var archiveStream = File.OpenRead(archive);
+
+            var archiveReader = ReaderFactory.Open(archiveStream);
+            var archiveOptions = new ExtractionOptions
+            {
+                Overwrite = overwrite,
+                ExtractFullPath = preserveRelativePaths
+            };
+
+            await Task.Run(() => archiveReader.WriteAllToDirectory(destination, archiveOptions));
+
+            return true;
         }
 
-        public async Task<bool> ExtractFilesAsync(string archive, string destination, List<string> targetFiles) => throw new NotImplementedException();
+        public async Task<bool> ExtractFilesAsync(
+            string archive,
+            string destination,
+            List<string> targetFiles,
+            Dictionary<string, string>? fileDestinations = null,
+            bool overwrite = false,
+            bool preserveRelativePaths = false)
+        {
+            // fileDestinations and targetFiles must contain the same number of entries if the former is not null.
+            if (fileDestinations is not null && targetFiles.Count != fileDestinations.Count)
+            {
+                // TODO: Replace with custom exception type.
+                throw new Exception("Failed while validating ExtractFilesAsync arguments: Entry count of fileDestinations does not match entryCount of targetFiles.");
+            }
+
+            using var archiveStream = File.OpenRead(archive);
+
+            var archiveReader = ArchiveFactory.Open(archiveStream);
+            var extractOptions = new ExtractionOptions
+            {
+                Overwrite = overwrite,
+                ExtractFullPath = preserveRelativePaths
+            };
+
+            // Warning: This method may be slow for certain compression formats -- most notably, LZMA and RAR. Needs future optimization.
+            foreach (var entry in archiveReader.Entries)
+            {
+                // Skipping directories for now as they should be created when files are extracted; should examine need for config.
+                if (entry.IsDirectory)
+                {
+                    continue;
+                }
+
+                // Extract the entry to the destination, using fileDestinations if an entry exists.
+                if (fileDestinations is not null && fileDestinations.ContainsKey(entry.Key))
+                {
+                    await Task.Run(() => entry.WriteToFile(Path.Combine(destination, fileDestinations[entry.Key])));
+                    continue;
+                }
+
+                // Otherwise, extract to the destination directory.
+                await Task.Run(() => entry.WriteToDirectory(destination, extractOptions));
+            }
+
+            return true;
+        }
     }
 }

--- a/source/gpm.core/Tasks/Install.cs
+++ b/source/gpm.core/Tasks/Install.cs
@@ -97,6 +97,8 @@ namespace gpm.Tasks
             if (releases is null || !releases.Any())
             {
                 Log.Warning("No releases found for package {Package}", package);
+                // clean slots for failed install
+                _ = model.Slots.Remove(slotId);
                 return false;
             }
 
@@ -107,10 +109,7 @@ namespace gpm.Tasks
             else
             {
                 // clean slots for failed install
-                //if (libraryService.TryGetValue(package.Id, out var model))
-                {
-                    _ = model.Slots.Remove(slotId);
-                }
+                _ = model.Slots.Remove(slotId);
                 return false;
             }
 
@@ -139,13 +138,15 @@ namespace gpm.Tasks
             if (!dependencyResult)
             {
                 Log.Warning("[{Package}] Some dependencies failed to install correctly", package);
+                return false;
             }
             else
             {
                 Log.Information("[{Package}] All dependencies installed successfully", package);
+                return true;
             }
 
-            return false;
+            
         }
 
         /// <summary>

--- a/source/gpm.core/gpm.core.csproj
+++ b/source/gpm.core/gpm.core.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="protobuf-net" Version="3.0.101" />
       <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
       <PackageReference Include="Serilog" Version="2.10.0" />
+      <PackageReference Include="SharpCompress" Version="0.30.1" />
   </ItemGroup>
 
 </Project>

--- a/source/gpm/Startup.cs
+++ b/source/gpm/Startup.cs
@@ -28,6 +28,7 @@ namespace gpm
         {
             services.AddScoped<IAppSettings, AppSettings>();
             services.AddScoped<IProgressService<double>, PercentProgressService>();
+            services.AddScoped<IArchiveService, ArchiveService>();
 
             services.AddSingleton<ILibraryService, LibraryService>();
             services.AddSingleton<IDataBaseService, DataBaseService>();


### PR DESCRIPTION
### Additions
+ Added SharpCompress as a nuget dependency to the `gpm.core` project.
+ Added IArchiveService.cs to standardize archive manipulation operations.
+ Added ArchiveService.cs, which implements the `IArchiveService` interface with SharpCompress.
+ Added `IArchiveService` dependency registration to Startup.cs, currently bound to the `ArchiveService` class.

### Changes
+ Updated `InstallPackageFromCache` to use `IArchiveService`.
+ Streamlined package `ContentType` determination when set to null.
+ Streamlined package installation.

Closes #9