### PR TITLE
Fix LibGit2Sharp not working on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -367,3 +367,6 @@ FodyWeavers.xsd
 
 # rider
 .idea/
+
+# Published builds
+publish-*/

--- a/source/gpm.core/gpm.core.csproj
+++ b/source/gpm.core/gpm.core.csproj
@@ -9,7 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="DynamicData" Version="7.4.9" />
-    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
+    <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0175" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.315-alpha.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="Octokit" Version="0.50.0" />


### PR DESCRIPTION
The latest stable version of LibGit2Sharp is quite old has a dependency of openssl
1.0, which is outdated and not included in many distributions. A preview
version released over a year ago removed this dependency so the package
has been updated to use a much more recent preview version.
LibGit2Sharp.NativeBinaries is included as an alpha as that is what is
required by LibGit2Sharp

Also added publish-* folders to the gitignore to skip over folders used
for publshing files